### PR TITLE
feat: extend BidirectionalKolo and KoloProvider for enhanced type safety and streaming support

### DIFF
--- a/core/src/main/kotlin/com/fatihcure/kolo/core/BidirectionalKoloBuilder.kt
+++ b/core/src/main/kotlin/com/fatihcure/kolo/core/BidirectionalKoloBuilder.kt
@@ -2,57 +2,75 @@ package com.fatihcure.kolo.core
 /**
  * Builder class for creating BidirectionalKolo instances
  */
-class BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
+class BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
     private var sourceNormalizer: Normalizer<SourceRequestType>? = null
     private var sourceTransformer: Transformer<SourceRequestType, SourceResponseType, SourceResponseType>? = null
+    private var sourceStreamingNormalizer: Normalizer<SourceStreamingResponseType>? = null
+    private var sourceStreamingTransformer: StreamingTransformer<SourceStreamingResponseType>? = null
     private var targetNormalizer: Normalizer<TargetResponseType>? = null
     private var targetTransformer: Transformer<TargetRequestType, TargetResponseType, TargetResponseType>? = null
-    private var sourceStreamingTransformer: StreamingTransformer<SourceResponseType>? = null
-    private var targetStreamingTransformer: StreamingTransformer<TargetResponseType>? = null
+    private var targetStreamingNormalizer: Normalizer<TargetStreamingResponseType>? = null
+    private var targetStreamingTransformer: StreamingTransformer<TargetStreamingResponseType>? = null
 
-    fun withSourceNormalizer(normalizer: Normalizer<SourceRequestType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
+    fun withSourceNormalizer(normalizer: Normalizer<SourceRequestType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
         this.sourceNormalizer = normalizer
         return this
     }
 
-    fun withSourceTransformer(transformer: Transformer<SourceRequestType, SourceResponseType, SourceResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
+    fun withSourceTransformer(transformer: Transformer<SourceRequestType, SourceResponseType, SourceResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
         this.sourceTransformer = transformer
         return this
     }
 
-    fun withTargetNormalizer(normalizer: Normalizer<TargetResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
-        this.targetNormalizer = normalizer
+    fun withSourceStreamingNormalizer(normalizer: Normalizer<SourceStreamingResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
+        this.sourceStreamingNormalizer = normalizer
         return this
     }
 
-    fun withTargetTransformer(transformer: Transformer<TargetRequestType, TargetResponseType, TargetResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
-        this.targetTransformer = transformer
-        return this
-    }
-
-    fun withSourceStreamingTransformer(transformer: StreamingTransformer<SourceResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
+    fun withSourceStreamingTransformer(transformer: StreamingTransformer<SourceStreamingResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
         this.sourceStreamingTransformer = transformer
         return this
     }
 
-    fun withTargetStreamingTransformer(transformer: StreamingTransformer<TargetResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
+    fun withTargetNormalizer(normalizer: Normalizer<TargetResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
+        this.targetNormalizer = normalizer
+        return this
+    }
+
+    fun withTargetTransformer(transformer: Transformer<TargetRequestType, TargetResponseType, TargetResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
+        this.targetTransformer = transformer
+        return this
+    }
+
+    fun withTargetStreamingNormalizer(normalizer: Normalizer<TargetStreamingResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
+        this.targetStreamingNormalizer = normalizer
+        return this
+    }
+
+    fun withTargetStreamingTransformer(transformer: StreamingTransformer<TargetStreamingResponseType>): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
         this.targetStreamingTransformer = transformer
         return this
     }
 
-    fun build(): BidirectionalKolo<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
+    fun build(): BidirectionalKolo<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
         require(sourceNormalizer != null) { "Source normalizer is required" }
         require(sourceTransformer != null) { "Source transformer is required" }
+        require(sourceStreamingNormalizer != null) { "Source streaming normalizer is required" }
+        require(sourceStreamingTransformer != null) { "Source streaming transformer is required" }
         require(targetNormalizer != null) { "Target normalizer is required" }
         require(targetTransformer != null) { "Target transformer is required" }
+        require(targetStreamingNormalizer != null) { "Target streaming normalizer is required" }
+        require(targetStreamingTransformer != null) { "Target streaming transformer is required" }
 
         return BidirectionalKolo(
             sourceNormalizer!!,
             sourceTransformer!!,
+            sourceStreamingNormalizer!!,
+            sourceStreamingTransformer!!,
             targetNormalizer!!,
             targetTransformer!!,
-            sourceStreamingTransformer,
-            targetStreamingTransformer,
+            targetStreamingNormalizer!!,
+            targetStreamingTransformer!!,
         )
     }
 }
@@ -60,20 +78,24 @@ class BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, TargetRequ
 /**
  * Factory function for creating BidirectionalKolo instances
  */
-fun <SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> bidirectionalKolo(
+fun <SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> bidirectionalKolo(
     sourceNormalizer: Normalizer<SourceRequestType>,
     sourceTransformer: Transformer<SourceRequestType, SourceResponseType, SourceResponseType>,
+    sourceStreamingNormalizer: Normalizer<SourceStreamingResponseType>,
+    sourceStreamingTransformer: StreamingTransformer<SourceStreamingResponseType>,
     targetNormalizer: Normalizer<TargetResponseType>,
     targetTransformer: Transformer<TargetRequestType, TargetResponseType, TargetResponseType>,
-    sourceStreamingTransformer: StreamingTransformer<SourceResponseType>? = null,
-    targetStreamingTransformer: StreamingTransformer<TargetResponseType>? = null,
-): BidirectionalKolo<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
+    targetStreamingNormalizer: Normalizer<TargetStreamingResponseType>,
+    targetStreamingTransformer: StreamingTransformer<TargetStreamingResponseType>,
+): BidirectionalKolo<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
     return BidirectionalKolo(
         sourceNormalizer,
         sourceTransformer,
+        sourceStreamingNormalizer,
+        sourceStreamingTransformer,
         targetNormalizer,
         targetTransformer,
-        sourceStreamingTransformer,
+        targetStreamingNormalizer,
         targetStreamingTransformer,
     )
 }
@@ -81,6 +103,6 @@ fun <SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseTyp
 /**
  * Factory function for creating BidirectionalKoloBuilder instances
  */
-fun <SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> bidirectionalKoloBuilder(): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, TargetRequestType, TargetResponseType> {
+fun <SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> bidirectionalKoloBuilder(): BidirectionalKoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, TargetRequestType, TargetResponseType, TargetStreamingResponseType> {
     return BidirectionalKoloBuilder()
 }

--- a/core/src/main/kotlin/com/fatihcure/kolo/core/ProviderAutoRegistration.kt
+++ b/core/src/main/kotlin/com/fatihcure/kolo/core/ProviderAutoRegistration.kt
@@ -9,6 +9,7 @@ import kotlin.reflect.KClass
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
+@Repeatable
 annotation class AutoRegisterNormalizer(val type: KClass<*>)
 
 /**
@@ -16,6 +17,7 @@ annotation class AutoRegisterNormalizer(val type: KClass<*>)
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
+@Repeatable
 annotation class AutoRegisterTransformer(val type: KClass<*>)
 
 /**
@@ -23,6 +25,7 @@ annotation class AutoRegisterTransformer(val type: KClass<*>)
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
+@Repeatable
 annotation class AutoRegisterStreamingTransformer(val type: KClass<*>)
 
 /**

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,9 +39,16 @@ Complete guide on how to use the Kolo library, including:
 
 3. **Bidirectional Conversion**
    ```kotlin
-   val bidirectionalKolo = provider.createBidirectionalKolo<OpenAIRequest, AnthropicRequest>()
+   val bidirectionalKolo = provider.createBidirectionalKolo<OpenAIRequest, OpenAIResponse, AnthropicRequest, AnthropicResponse, OpenAIStreamEvent, AnthropicStreamEvent>()
    val converted = bidirectionalKolo.convertRequest(openAIRequest)
    val backToOriginal = bidirectionalKolo.convertResponse(anthropicResponse)
+   ```
+
+4. **Streaming Conversion**
+   ```kotlin
+   val anthropicStream: Flow<AnthropicStreamEvent> = /* your stream */
+   val openAIStream: Flow<OpenAIStreamEvent> = bidirectionalKolo.convertStreamingResponse(anthropicStream)
+   openAIStream.collect { event -> /* process converted events */ }
    ```
 
 ## Key Features
@@ -81,6 +88,13 @@ graph TD
     J --> K["Transformer<br/>(IF → OpenAI)"]
     K --> L["OpenAI-format response"]
     L --> A
+    
+    G --> M["Anthropic streaming response"]
+    M --> N["Streaming Normalizer<br/>(Anthropic → IF)"]
+    N --> O["Intermittent Stream Events"]
+    O --> P["Streaming Transformer<br/>(IF → OpenAI)"]
+    P --> Q["OpenAI streaming response"]
+    Q --> A
 ```
 
 This approach reduces complexity from O(N²) to O(N) conversions.

--- a/normalizers/src/main/kotlin/com/fatihcure/kolo/normalizers/anthropic/AnthropicNormalizer.kt
+++ b/normalizers/src/main/kotlin/com/fatihcure/kolo/normalizers/anthropic/AnthropicNormalizer.kt
@@ -1,5 +1,6 @@
 package com.fatihcure.kolo.normalizers.anthropic
 
+import com.fatihcure.kolo.core.AutoRegisterNormalizer
 import com.fatihcure.kolo.core.ErrorNormalizer
 import com.fatihcure.kolo.core.IntermittentChoice
 import com.fatihcure.kolo.core.IntermittentDelta
@@ -23,6 +24,10 @@ import kotlinx.coroutines.flow.map
 /**
  * Normalizer implementation for Anthropic Claude API
  */
+@AutoRegisterNormalizer(AnthropicRequest::class)
+@AutoRegisterNormalizer(AnthropicResponse::class)
+@AutoRegisterNormalizer(AnthropicStreamEvent::class)
+@AutoRegisterNormalizer(AnthropicError::class)
 class AnthropicNormalizer : RequestNormalizer<AnthropicRequest>, ResponseNormalizer<AnthropicResponse>, StreamingNormalizer<AnthropicStreamEvent>, ErrorNormalizer<AnthropicError> {
 
     override fun normalizeRequest(request: AnthropicRequest): IntermittentRequest {

--- a/normalizers/src/main/kotlin/com/fatihcure/kolo/normalizers/openai/OpenAINormalizer.kt
+++ b/normalizers/src/main/kotlin/com/fatihcure/kolo/normalizers/openai/OpenAINormalizer.kt
@@ -1,5 +1,6 @@
 package com.fatihcure.kolo.normalizers.openai
 
+import com.fatihcure.kolo.core.AutoRegisterNormalizer
 import com.fatihcure.kolo.core.ErrorNormalizer
 import com.fatihcure.kolo.core.IntermittentChoice
 import com.fatihcure.kolo.core.IntermittentDelta
@@ -19,6 +20,10 @@ import kotlinx.coroutines.flow.map
 /**
  * Normalizer implementation for OpenAI API
  */
+@AutoRegisterNormalizer(OpenAIRequest::class)
+@AutoRegisterNormalizer(OpenAIResponse::class)
+@AutoRegisterNormalizer(OpenAIStreamingResponse::class)
+@AutoRegisterNormalizer(OpenAIError::class)
 class OpenAINormalizer : RequestNormalizer<OpenAIRequest>, ResponseNormalizer<OpenAIResponse>, StreamingNormalizer<OpenAIStreamingResponse>, ErrorNormalizer<OpenAIError> {
 
     override fun normalizeRequest(request: OpenAIRequest): IntermittentRequest {

--- a/providers/src/main/kotlin/com/fatihcure/kolo/providers/KoloProvider.kt
+++ b/providers/src/main/kotlin/com/fatihcure/kolo/providers/KoloProvider.kt
@@ -42,24 +42,24 @@ class KoloProvider {
             anthropicProvider,
         )
 
-        // Register normalizers for streaming response types
+        // Register normalizers for streaming event types
         val openAINormalizer = com.fatihcure.kolo.normalizers.openai.OpenAINormalizer()
-        val openAIStreamingNormalizer = object : com.fatihcure.kolo.core.Normalizer<com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse> {
-            override fun normalizeRequest(request: com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse): com.fatihcure.kolo.core.IntermittentRequest {
-                throw UnsupportedOperationException("Streaming responses don't have requests")
+        val openAIStreamingNormalizer = object : com.fatihcure.kolo.core.Normalizer<com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent> {
+            override fun normalizeRequest(request: com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent): com.fatihcure.kolo.core.IntermittentRequest {
+                throw UnsupportedOperationException("Streaming events don't have requests")
             }
-            override fun normalizeResponse(response: com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse): com.fatihcure.kolo.core.IntermittentResponse {
-                throw UnsupportedOperationException("Use normalizeStreamingResponse for streaming responses")
+            override fun normalizeResponse(response: com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent): com.fatihcure.kolo.core.IntermittentResponse {
+                throw UnsupportedOperationException("Use normalizeStreamingResponse for streaming events")
             }
-            override fun normalizeStreamingResponse(stream: kotlinx.coroutines.flow.Flow<com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse>): kotlinx.coroutines.flow.Flow<com.fatihcure.kolo.core.IntermittentStreamEvent> {
-                return openAINormalizer.normalizeStreamingResponse(stream)
+            override fun normalizeStreamingResponse(stream: kotlinx.coroutines.flow.Flow<com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent>): kotlinx.coroutines.flow.Flow<com.fatihcure.kolo.core.IntermittentStreamEvent> {
+                return openAINormalizer.normalizeStreamEvent(stream)
             }
-            override fun normalizeError(error: com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse): com.fatihcure.kolo.core.IntermittentError {
-                throw UnsupportedOperationException("Use normalizeStreamingResponse for streaming responses")
+            override fun normalizeError(error: com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent): com.fatihcure.kolo.core.IntermittentError {
+                throw UnsupportedOperationException("Use normalizeStreamingResponse for streaming events")
             }
         }
         GlobalProviderAutoRegistration.registerNormalizer(
-            com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse::class,
+            com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent::class,
             openAIStreamingNormalizer,
         )
 
@@ -83,11 +83,11 @@ class KoloProvider {
             anthropicStreamingNormalizer,
         )
 
-        // Register streaming transformers for streaming response types
+        // Register streaming transformers for streaming event types
         val openAITransformer = com.fatihcure.kolo.transformers.openai.OpenAITransformer()
         GlobalProviderAutoRegistration.registerStreamingTransformer(
-            com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse::class,
-            openAITransformer as com.fatihcure.kolo.core.StreamingTransformer<com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse>,
+            com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent::class,
+            openAITransformer as com.fatihcure.kolo.core.StreamingTransformer<com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent>,
         )
 
         val anthropicTransformer = com.fatihcure.kolo.transformers.anthropic.AnthropicTransformer()

--- a/providers/src/main/kotlin/com/fatihcure/kolo/providers/OpenAIProvider.kt
+++ b/providers/src/main/kotlin/com/fatihcure/kolo/providers/OpenAIProvider.kt
@@ -11,6 +11,7 @@ import com.fatihcure.kolo.normalizers.openai.OpenAIError
 import com.fatihcure.kolo.normalizers.openai.OpenAINormalizer
 import com.fatihcure.kolo.normalizers.openai.OpenAIRequest
 import com.fatihcure.kolo.normalizers.openai.OpenAIResponse
+import com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent
 import com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse
 import com.fatihcure.kolo.normalizers.openai.createOpenAIStreamingHandler
 import com.fatihcure.kolo.transformers.openai.OpenAITransformer
@@ -22,7 +23,7 @@ import kotlinx.coroutines.flow.Flow
 @AutoRegisterProvider(OpenAIRequest::class, OpenAIResponse::class)
 class OpenAIProvider(
     private val config: OpenAIProviderConfig = OpenAIProviderConfig.default(),
-) : Provider<OpenAIRequest, OpenAIResponse, OpenAIStreamingResponse, OpenAIError> {
+) : Provider<OpenAIRequest, OpenAIResponse, OpenAIStreamEvent, OpenAIError> {
 
     private val normalizer = OpenAINormalizer()
     private val transformer = OpenAITransformer()
@@ -56,11 +57,11 @@ class OpenAIProvider(
     }
 
     // Streaming support
-    override fun normalizeStreamingResponse(stream: Flow<OpenAIStreamingResponse>): Flow<IntermittentStreamEvent> {
-        return normalizer.normalizeStreamingResponse(stream)
+    override fun normalizeStreamingResponse(stream: Flow<OpenAIStreamEvent>): Flow<IntermittentStreamEvent> {
+        return normalizer.normalizeStreamEvent(stream)
     }
 
-    override fun transformStreamingResponse(stream: Flow<IntermittentStreamEvent>): Flow<OpenAIStreamingResponse> {
+    override fun transformStreamingResponse(stream: Flow<IntermittentStreamEvent>): Flow<OpenAIStreamEvent> {
         return transformer.transformStreamingResponse(stream)
     }
 

--- a/providers/src/test/kotlin/com/fatihcure/kolo/providers/KoloProviderTest.kt
+++ b/providers/src/test/kotlin/com/fatihcure/kolo/providers/KoloProviderTest.kt
@@ -45,8 +45,10 @@ class KoloProviderTest {
         val bidirectionalKolo = koloProvider.createBidirectionalKolo(
             OpenAIRequest::class,
             OpenAIResponse::class,
+            com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse::class,
             AnthropicRequest::class,
             AnthropicResponse::class,
+            com.fatihcure.kolo.normalizers.anthropic.AnthropicStreamEvent::class,
         )
 
         // Then
@@ -67,7 +69,7 @@ class KoloProviderTest {
     @Test
     fun `should create bidirectional Kolo instance using reified types`() {
         // When
-        val bidirectionalKolo = koloProvider.createBidirectionalKolo<OpenAIRequest, OpenAIResponse, AnthropicRequest, AnthropicResponse>()
+        val bidirectionalKolo = koloProvider.createBidirectionalKolo<OpenAIRequest, OpenAIResponse, com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse, AnthropicRequest, AnthropicResponse, com.fatihcure.kolo.normalizers.anthropic.AnthropicStreamEvent>()
 
         // Then
         assertThat(bidirectionalKolo).isNotNull

--- a/providers/src/test/kotlin/com/fatihcure/kolo/providers/KoloProviderTest.kt
+++ b/providers/src/test/kotlin/com/fatihcure/kolo/providers/KoloProviderTest.kt
@@ -45,7 +45,7 @@ class KoloProviderTest {
         val bidirectionalKolo = koloProvider.createBidirectionalKolo(
             OpenAIRequest::class,
             OpenAIResponse::class,
-            com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse::class,
+            com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent::class,
             AnthropicRequest::class,
             AnthropicResponse::class,
             com.fatihcure.kolo.normalizers.anthropic.AnthropicStreamEvent::class,
@@ -69,7 +69,7 @@ class KoloProviderTest {
     @Test
     fun `should create bidirectional Kolo instance using reified types`() {
         // When
-        val bidirectionalKolo = koloProvider.createBidirectionalKolo<OpenAIRequest, OpenAIResponse, com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse, AnthropicRequest, AnthropicResponse, com.fatihcure.kolo.normalizers.anthropic.AnthropicStreamEvent>()
+        val bidirectionalKolo = koloProvider.createBidirectionalKolo<OpenAIRequest, OpenAIResponse, com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent, AnthropicRequest, AnthropicResponse, com.fatihcure.kolo.normalizers.anthropic.AnthropicStreamEvent>()
 
         // Then
         assertThat(bidirectionalKolo).isNotNull

--- a/providers/src/test/kotlin/com/fatihcure/kolo/providers/OpenAIProviderTest.kt
+++ b/providers/src/test/kotlin/com/fatihcure/kolo/providers/OpenAIProviderTest.kt
@@ -8,6 +8,7 @@ import com.fatihcure.kolo.normalizers.openai.OpenAIChoice
 import com.fatihcure.kolo.normalizers.openai.OpenAIMessage
 import com.fatihcure.kolo.normalizers.openai.OpenAIRequest
 import com.fatihcure.kolo.normalizers.openai.OpenAIResponse
+import com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent
 import com.fatihcure.kolo.normalizers.openai.OpenAIUsage
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -146,12 +147,12 @@ class OpenAIProviderTest {
     @Test
     fun `should normalize streaming response`() = runBlocking {
         // Given
-        val openAIStreamingResponse = com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse(
+        val openAIStreamEvent = com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent(
             id = "test-id",
             model = "gpt-3.5-turbo",
             choices = emptyList(),
         )
-        val stream = flowOf(openAIStreamingResponse)
+        val stream = flowOf(openAIStreamEvent)
 
         // When
         val result = openAIProvider.normalizeStreamingResponse(stream).first()

--- a/providers/src/test/kotlin/com/fatihcure/kolo/providers/ProviderIntegrationTest.kt
+++ b/providers/src/test/kotlin/com/fatihcure/kolo/providers/ProviderIntegrationTest.kt
@@ -95,7 +95,7 @@ class ProviderIntegrationTest {
         val bidirectionalKolo = koloProvider.createBidirectionalKolo(
             OpenAIRequest::class,
             OpenAIResponse::class,
-            com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse::class,
+            com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent::class,
             AnthropicRequest::class,
             AnthropicResponse::class,
             com.fatihcure.kolo.normalizers.anthropic.AnthropicStreamEvent::class,

--- a/providers/src/test/kotlin/com/fatihcure/kolo/providers/ProviderIntegrationTest.kt
+++ b/providers/src/test/kotlin/com/fatihcure/kolo/providers/ProviderIntegrationTest.kt
@@ -95,8 +95,10 @@ class ProviderIntegrationTest {
         val bidirectionalKolo = koloProvider.createBidirectionalKolo(
             OpenAIRequest::class,
             OpenAIResponse::class,
+            com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse::class,
             AnthropicRequest::class,
             AnthropicResponse::class,
+            com.fatihcure.kolo.normalizers.anthropic.AnthropicStreamEvent::class,
         )
         val anthropicRequest = bidirectionalKolo.convertRequest(openAIRequest)
 

--- a/providers/src/test/kotlin/com/fatihcure/kolo/providers/ProviderTypealiasTest.kt
+++ b/providers/src/test/kotlin/com/fatihcure/kolo/providers/ProviderTypealiasTest.kt
@@ -8,7 +8,7 @@ import com.fatihcure.kolo.normalizers.anthropic.AnthropicStreamEvent
 import com.fatihcure.kolo.normalizers.openai.OpenAIError
 import com.fatihcure.kolo.normalizers.openai.OpenAIRequest
 import com.fatihcure.kolo.normalizers.openai.OpenAIResponse
-import com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse
+import com.fatihcure.kolo.normalizers.openai.OpenAIStreamEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -36,7 +36,7 @@ class ProviderTypealiasTest {
 
         // When & Then
         // These should compile without issues, indicating correct generic type implementation
-        val openAIProviderTyped: Provider<OpenAIRequest, OpenAIResponse, OpenAIStreamingResponse, OpenAIError> = openAIProvider
+        val openAIProviderTyped: Provider<OpenAIRequest, OpenAIResponse, OpenAIStreamEvent, OpenAIError> = openAIProvider
         val anthropicProviderTyped: Provider<AnthropicRequest, AnthropicResponse, AnthropicStreamEvent, AnthropicError> = anthropicProvider
 
         assertThat(openAIProviderTyped).isNotNull()


### PR DESCRIPTION
- Refactor BidirectionalKolo and BidirectionalKoloBuilder to include separate types for streaming responses.
- Update GenericProviderFactory and KoloProvider to accommodate new type parameters for streaming.
- Introduce new factory methods for creating BidirectionalKolo instances with streaming support.
- Enhance tests to validate the new functionality, ensuring correct behavior for both standard and streaming conversions.
- Register normalizers and transformers for streaming response types in KoloProvider.