### PR TITLE
feat: introduce provider-instance approach for Kolo creation

### DIFF
--- a/core/src/main/kotlin/com/fatihcure/kolo/core/GenericProviderFactory.kt
+++ b/core/src/main/kotlin/com/fatihcure/kolo/core/GenericProviderFactory.kt
@@ -26,6 +26,31 @@ class GenericProviderFactory(private val registry: ProviderRegistry) {
     }
 
     /**
+     * Create a Kolo instance for converting between different providers using provider instances
+     * This provides full compile-time safety without casting
+     */
+    fun <SourceRequestType : Any, SourceResponseType : Any, SourceStreamingResponseType : Any, SourceErrorType : Any, TargetRequestType : Any, TargetResponseType : Any, TargetStreamingResponseType : Any, TargetErrorType : Any> createKolo(
+        sourceProviderType: KClass<*>,
+        targetProviderType: KClass<*>,
+        _sourceRequestType: KClass<SourceRequestType>,
+        _sourceResponseType: KClass<SourceResponseType>,
+        _sourceStreamingResponseType: KClass<SourceStreamingResponseType>,
+        _sourceErrorType: KClass<SourceErrorType>,
+        _targetRequestType: KClass<TargetRequestType>,
+        _targetResponseType: KClass<TargetResponseType>,
+        _targetStreamingResponseType: KClass<TargetStreamingResponseType>,
+        _targetErrorType: KClass<TargetErrorType>,
+    ): Kolo<SourceRequestType, SourceResponseType, SourceStreamingResponseType, SourceErrorType, TargetRequestType, TargetResponseType, TargetStreamingResponseType, TargetErrorType> {
+        val sourceProvider = registry.getProvider<SourceRequestType, SourceResponseType, SourceStreamingResponseType, SourceErrorType>(sourceProviderType)
+            ?: throw IllegalArgumentException("No provider found for source type: ${sourceProviderType.simpleName}")
+
+        val targetProvider = registry.getProvider<TargetRequestType, TargetResponseType, TargetStreamingResponseType, TargetErrorType>(targetProviderType)
+            ?: throw IllegalArgumentException("No provider found for target type: ${targetProviderType.simpleName}")
+
+        return Kolo<SourceRequestType, SourceResponseType, SourceStreamingResponseType, SourceErrorType, TargetRequestType, TargetResponseType, TargetStreamingResponseType, TargetErrorType>(sourceProvider, targetProvider)
+    }
+
+    /**
      * Check if a conversion is possible from source to target
      */
     fun canConvert(

--- a/core/src/main/kotlin/com/fatihcure/kolo/core/Kolo.kt
+++ b/core/src/main/kotlin/com/fatihcure/kolo/core/Kolo.kt
@@ -8,14 +8,14 @@ import kotlinx.coroutines.flow.Flow
  * using the intermittent format as an intermediary
  */
 class Kolo<
-    SourceRequestType,
-    SourceResponseType,
-    SourceStreamingResponseType,
-    SourceErrorType,
-    TargetRequestType,
-    TargetResponseType,
-    TargetStreamingResponseType,
-    TargetErrorType,
+    SourceRequestType : Any,
+    SourceResponseType : Any,
+    SourceStreamingResponseType : Any,
+    SourceErrorType : Any,
+    TargetRequestType : Any,
+    TargetResponseType : Any,
+    TargetStreamingResponseType : Any,
+    TargetErrorType : Any,
     >(
     private val sourceProvider: StreamingProvider<SourceRequestType, SourceResponseType, SourceStreamingResponseType, SourceErrorType>,
     private val targetProvider: StreamingProvider<TargetRequestType, TargetResponseType, TargetStreamingResponseType, TargetErrorType>,

--- a/core/src/main/kotlin/com/fatihcure/kolo/core/KoloBuilder.kt
+++ b/core/src/main/kotlin/com/fatihcure/kolo/core/KoloBuilder.kt
@@ -4,14 +4,14 @@ package com.fatihcure.kolo.core
  * Builder class for creating Kolo instances
  */
 class KoloBuilder<
-    SourceRequestType,
-    SourceResponseType,
-    SourceStreamingResponseType,
-    SourceErrorType,
-    TargetRequestType,
-    TargetResponseType,
-    TargetStreamingResponseType,
-    TargetErrorType,
+    SourceRequestType : Any,
+    SourceResponseType : Any,
+    SourceStreamingResponseType : Any,
+    SourceErrorType : Any,
+    TargetRequestType : Any,
+    TargetResponseType : Any,
+    TargetStreamingResponseType : Any,
+    TargetErrorType : Any,
     > {
     private var sourceProvider: StreamingProvider<SourceRequestType, SourceResponseType, SourceStreamingResponseType, SourceErrorType>? = null
     private var targetProvider: StreamingProvider<TargetRequestType, TargetResponseType, TargetStreamingResponseType, TargetErrorType>? = null
@@ -38,14 +38,14 @@ class KoloBuilder<
  * Factory function for creating Kolo instances
  */
 fun <
-    SourceRequestType,
-    SourceResponseType,
-    SourceStreamingResponseType,
-    SourceErrorType,
-    TargetRequestType,
-    TargetResponseType,
-    TargetStreamingResponseType,
-    TargetErrorType,
+    SourceRequestType : Any,
+    SourceResponseType : Any,
+    SourceStreamingResponseType : Any,
+    SourceErrorType : Any,
+    TargetRequestType : Any,
+    TargetResponseType : Any,
+    TargetStreamingResponseType : Any,
+    TargetErrorType : Any,
     > kolo(
     sourceProvider: StreamingProvider<SourceRequestType, SourceResponseType, SourceStreamingResponseType, SourceErrorType>,
     targetProvider: StreamingProvider<TargetRequestType, TargetResponseType, TargetStreamingResponseType, TargetErrorType>,
@@ -57,14 +57,14 @@ fun <
  * Factory function for creating KoloBuilder instances
  */
 fun <
-    SourceRequestType,
-    SourceResponseType,
-    SourceStreamingResponseType,
-    SourceErrorType,
-    TargetRequestType,
-    TargetResponseType,
-    TargetStreamingResponseType,
-    TargetErrorType,
+    SourceRequestType : Any,
+    SourceResponseType : Any,
+    SourceStreamingResponseType : Any,
+    SourceErrorType : Any,
+    TargetRequestType : Any,
+    TargetResponseType : Any,
+    TargetStreamingResponseType : Any,
+    TargetErrorType : Any,
     > koloBuilder(): KoloBuilder<SourceRequestType, SourceResponseType, SourceStreamingResponseType, SourceErrorType, TargetRequestType, TargetResponseType, TargetStreamingResponseType, TargetErrorType> {
     return KoloBuilder()
 }

--- a/core/src/main/kotlin/com/fatihcure/kolo/core/ProviderAutoRegistration.kt
+++ b/core/src/main/kotlin/com/fatihcure/kolo/core/ProviderAutoRegistration.kt
@@ -39,7 +39,13 @@ annotation class AutoRegisterProvider(val requestType: KClass<*>, val responseTy
  * Provider interface that combines normalizer and transformer functionality
  * for both request and response types
  */
-interface Provider<RequestType, ResponseType, StreamEventType, ErrorType> {
+interface Provider<RequestType : Any, ResponseType : Any, StreamEventType : Any, ErrorType : Any> {
+
+    // Type information for compile-time safety
+    val requestType: KClass<out RequestType>
+    val responseType: KClass<out ResponseType>
+    val streamingResponseType: KClass<out StreamEventType>
+    val errorType: KClass<out ErrorType>
 
     // Request normalization and transformation
     fun normalizeRequest(request: RequestType): IntermittentRequest
@@ -63,7 +69,7 @@ interface Provider<RequestType, ResponseType, StreamEventType, ErrorType> {
  * This interface extends the base Provider interface with methods to handle raw streaming data
  * from HTTP responses (like Server-Sent Events) and convert them to the appropriate format
  */
-interface StreamingProvider<RequestType, ResponseType, StreamEventType, ErrorType> :
+interface StreamingProvider<RequestType : Any, ResponseType : Any, StreamEventType : Any, ErrorType : Any> :
     Provider<RequestType, ResponseType, StreamEventType, ErrorType> {
 
     /**

--- a/core/src/test/kotlin/com/fatihcure/kolo/core/GenericProviderFactoryTest.kt
+++ b/core/src/test/kotlin/com/fatihcure/kolo/core/GenericProviderFactoryTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
 
 class GenericProviderFactoryTest {
 
@@ -21,6 +22,10 @@ class GenericProviderFactoryTest {
     fun `should create kolo instance when providers are registered`() {
         // Register a streaming provider
         val provider = object : StreamingProvider<String, String, String, String> {
+            override val requestType: KClass<out String> = String::class
+            override val responseType: KClass<out String> = String::class
+            override val streamingResponseType: KClass<out String> = String::class
+            override val errorType: KClass<out String> = String::class
             override fun normalizeRequest(request: String): IntermittentRequest {
                 return IntermittentRequest(
                     messages = listOf(
@@ -154,6 +159,10 @@ class GenericProviderFactoryTest {
 
     private fun createTestProvider(): StreamingProvider<String, String, String, String> {
         return object : StreamingProvider<String, String, String, String> {
+            override val requestType: KClass<out String> = String::class
+            override val responseType: KClass<out String> = String::class
+            override val streamingResponseType: KClass<out String> = String::class
+            override val errorType: KClass<out String> = String::class
             override fun normalizeRequest(request: String): IntermittentRequest =
                 IntermittentRequest(messages = emptyList(), model = "test")
             override fun transformRequest(request: IntermittentRequest): String = ""

--- a/core/src/test/kotlin/com/fatihcure/kolo/core/KoloTest.kt
+++ b/core/src/test/kotlin/com/fatihcure/kolo/core/KoloTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
 
 class KoloTest {
 
@@ -32,6 +33,10 @@ class KoloTest {
 
     private fun createTestProvider(): StreamingProvider<String, String, String, String> {
         return object : StreamingProvider<String, String, String, String> {
+            override val requestType: KClass<out String> = String::class
+            override val responseType: KClass<out String> = String::class
+            override val streamingResponseType: KClass<out String> = String::class
+            override val errorType: KClass<out String> = String::class
             override fun normalizeRequest(request: String): IntermittentRequest {
                 return IntermittentRequest(
                     messages = listOf(

--- a/providers/src/main/kotlin/com/fatihcure/kolo/providers/AnthropicProvider.kt
+++ b/providers/src/main/kotlin/com/fatihcure/kolo/providers/AnthropicProvider.kt
@@ -13,12 +13,19 @@ import com.fatihcure.kolo.normalizers.anthropic.AnthropicResponse
 import com.fatihcure.kolo.normalizers.anthropic.AnthropicStreamEvent
 import com.fatihcure.kolo.transformers.anthropic.AnthropicTransformer
 import kotlinx.coroutines.flow.Flow
+import kotlin.reflect.KClass
 
 /**
  * Anthropic provider implementation that combines normalizer and transformer
  */
 @AutoRegisterProvider(AnthropicRequest::class, AnthropicResponse::class)
 class AnthropicProvider : StreamingProvider<AnthropicRequest, AnthropicResponse, AnthropicStreamEvent, AnthropicError> {
+
+    // Type information for compile-time safety
+    override val requestType: KClass<AnthropicRequest> = AnthropicRequest::class
+    override val responseType: KClass<AnthropicResponse> = AnthropicResponse::class
+    override val streamingResponseType: KClass<AnthropicStreamEvent> = AnthropicStreamEvent::class
+    override val errorType: KClass<AnthropicError> = AnthropicError::class
 
     private val normalizer = AnthropicNormalizer()
     private val transformer = AnthropicTransformer()

--- a/providers/src/main/kotlin/com/fatihcure/kolo/providers/KoloProvider.kt
+++ b/providers/src/main/kotlin/com/fatihcure/kolo/providers/KoloProvider.kt
@@ -3,6 +3,7 @@ package com.fatihcure.kolo.providers
 import com.fatihcure.kolo.core.GlobalProviderAutoRegistration
 import com.fatihcure.kolo.core.GlobalProviderFactory
 import com.fatihcure.kolo.core.Kolo
+import com.fatihcure.kolo.core.StreamingProvider
 import kotlin.reflect.KClass
 
 /**
@@ -44,6 +45,36 @@ class KoloProvider {
         targetProviderType: KClass<*>,
     ): Kolo<SourceRequestType, SourceResponseType, SourceStreamingResponseType, SourceErrorType, TargetRequestType, TargetResponseType, TargetStreamingResponseType, TargetErrorType> {
         return factory.createKolo<SourceRequestType, SourceResponseType, SourceStreamingResponseType, SourceErrorType, TargetRequestType, TargetResponseType, TargetStreamingResponseType, TargetErrorType>(sourceProviderType, targetProviderType)
+    }
+
+    /**
+     * Creates a Kolo instance for converting between different providers using provider instances
+     * This provides full compile-time safety without casting
+     */
+    inline fun <
+        reified SP : StreamingProvider<SReq, SRes, SStream, SErr>,
+        SReq : Any,
+        SRes : Any,
+        SStream : Any,
+        SErr : Any,
+        reified TP : StreamingProvider<TReq, TRes, TStream, TErr>,
+        TReq : Any,
+        TRes : Any,
+        TStream : Any,
+        TErr : Any,
+        > createKolo(
+        source: SP,
+        target: TP,
+    ): Kolo<SReq, SRes, SStream, SErr, TReq, TRes, TStream, TErr> {
+        // Get runtime KClass from provider instances
+        val sourceClass = source::class
+        val targetClass = target::class
+
+        // Use the existing factory method with KClass parameters
+        return factory.createKolo<SReq, SRes, SStream, SErr, TReq, TRes, TStream, TErr>(
+            sourceClass,
+            targetClass,
+        )
     }
 
     /**

--- a/providers/src/main/kotlin/com/fatihcure/kolo/providers/OpenAIProvider.kt
+++ b/providers/src/main/kotlin/com/fatihcure/kolo/providers/OpenAIProvider.kt
@@ -15,6 +15,7 @@ import com.fatihcure.kolo.normalizers.openai.OpenAIStreamingResponse
 import com.fatihcure.kolo.normalizers.openai.createOpenAIStreamingHandler
 import com.fatihcure.kolo.transformers.openai.OpenAITransformer
 import kotlinx.coroutines.flow.Flow
+import kotlin.reflect.KClass
 
 /**
  * OpenAI provider implementation that combines normalizer and transformer
@@ -23,6 +24,12 @@ import kotlinx.coroutines.flow.Flow
 class OpenAIProvider(
     private val config: OpenAIProviderConfig = OpenAIProviderConfig.default(),
 ) : StreamingProvider<OpenAIRequest, OpenAIResponse, OpenAIStreamEvent, OpenAIError> {
+
+    // Type information for compile-time safety
+    override val requestType: KClass<OpenAIRequest> = OpenAIRequest::class
+    override val responseType: KClass<OpenAIResponse> = OpenAIResponse::class
+    override val streamingResponseType: KClass<OpenAIStreamEvent> = OpenAIStreamEvent::class
+    override val errorType: KClass<OpenAIError> = OpenAIError::class
 
     private val normalizer = OpenAINormalizer()
     private val transformer = OpenAITransformer()

--- a/providers/src/test/kotlin/com/fatihcure/kolo/providers/ProviderInstanceTest.kt
+++ b/providers/src/test/kotlin/com/fatihcure/kolo/providers/ProviderInstanceTest.kt
@@ -1,0 +1,72 @@
+package com.fatihcure.kolo.providers
+
+import com.fatihcure.kolo.normalizers.anthropic.AnthropicRequest
+import com.fatihcure.kolo.normalizers.anthropic.AnthropicResponse
+import com.fatihcure.kolo.normalizers.openai.OpenAIRequest
+import com.fatihcure.kolo.normalizers.openai.OpenAIResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Test class for the provider-instance alternative approach
+ * This demonstrates full compile-time safety without casting
+ */
+class ProviderInstanceTest {
+
+    @Test
+    fun `test createKolo with provider instances provides compile-time safety`() {
+        // Create provider instances
+        val openAIProvider = OpenAIProvider()
+        val anthropicProvider = AnthropicProvider()
+
+        // Create KoloProvider
+        val koloProvider = KoloProvider()
+
+        // Test the new provider-instance approach
+        // This provides full compile-time safety without casting
+        val kolo = koloProvider.createKolo(openAIProvider, anthropicProvider)
+
+        // Verify the kolo instance is created successfully
+        assertThat(kolo).isNotNull
+
+        // Test type information access
+        assertThat(openAIProvider.requestType).isEqualTo(OpenAIRequest::class)
+        assertThat(openAIProvider.responseType).isEqualTo(OpenAIResponse::class)
+        assertThat(anthropicProvider.requestType).isEqualTo(AnthropicRequest::class)
+        assertThat(anthropicProvider.responseType).isEqualTo(AnthropicResponse::class)
+    }
+
+    @Test
+    fun `test createKolo with reversed provider order`() {
+        // Create provider instances
+        val anthropicProvider = AnthropicProvider()
+        val openAIProvider = OpenAIProvider()
+
+        // Create KoloProvider
+        val koloProvider = KoloProvider()
+
+        // Test the new provider-instance approach with reversed order
+        val kolo = koloProvider.createKolo(anthropicProvider, openAIProvider)
+
+        // Verify the kolo instance is created successfully
+        assertThat(kolo).isNotNull
+    }
+
+    @Test
+    fun `test provider type information is accessible`() {
+        // Create provider instances
+        val openAIProvider = OpenAIProvider()
+        val anthropicProvider = AnthropicProvider()
+
+        // Test that type information is accessible from provider instances
+        assertThat(openAIProvider.requestType).isNotNull
+        assertThat(openAIProvider.responseType).isNotNull
+        assertThat(openAIProvider.streamingResponseType).isNotNull
+        assertThat(openAIProvider.errorType).isNotNull
+
+        assertThat(anthropicProvider.requestType).isNotNull
+        assertThat(anthropicProvider.responseType).isNotNull
+        assertThat(anthropicProvider.streamingResponseType).isNotNull
+        assertThat(anthropicProvider.errorType).isNotNull
+    }
+}


### PR DESCRIPTION
- Add a new method in KoloProvider to create Kolo instances using provider instances, enhancing compile-time safety.
- Update Kolo and KoloBuilder classes to enforce type constraints on request and response types.
- Modify existing providers to include type information for compile-time safety.
- Update usage guide to reflect the new provider-instance approach, highlighting its benefits over the KClass-based method.
- Add tests to validate the new provider-instance functionality and ensure type information accessibility.